### PR TITLE
subtest() should use note() rather than diag()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ Revision history for lua-TestMore
 
 0.3.4  Sun Feb 25 22:10:00 2018
         make subtest() use note() instead of diag(), like in Perl's Test::Builder
+        disable buffering for output filehandles
 
 0.3.3  Sat Jan 20 17:30:00 2018
 	shadow _ENV

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 Revision history for lua-TestMore
 
+0.3.4  Sun Feb 25 22:10:00 2018
+        make subtest() use note() instead of diag(), like in Perl's Test::Builder
+
 0.3.3  Sat Jan 20 17:30:00 2018
 	shadow _ENV
 	add Debian package infrastructure

--- a/dist.info
+++ b/dist.info
@@ -1,6 +1,6 @@
 
 name = "lua-testmore"
-version = "0.3.3"
+version = "0.3.4"
 
 desc = "an Unit Testing Framework"
 author = "Francois Perrad"

--- a/src/Test/Builder.lua
+++ b/src/Test/Builder.lua
@@ -103,7 +103,7 @@ function m:subtest (name, func)
     if type(func) ~= 'function' then
         error("subtest()'s second argument must be a function")
     end
-    self:diag('Subtest: ' .. name)
+    self:note('Subtest: ' .. name)
     local child = self:child(name)
     local parent = self.data
     self.data = child.data

--- a/src/Test/Builder.lua
+++ b/src/Test/Builder.lua
@@ -25,6 +25,9 @@ local m = {}
 local testout = io and io.stdout
 local testerr = io and (io.stderr or io.stdout)
 
+testout:setvbuf('no')
+testerr:setvbuf('no')
+
 function m.puts (f, str)
     f:write(str)
 end

--- a/src/Test/More.lua
+++ b/src/Test/More.lua
@@ -375,7 +375,7 @@ for k, v in pairs(m) do  -- injection
     _G[k] = v
 end
 
-m._VERSION = "0.3.3"
+m._VERSION = "0.3.4"
 m._DESCRIPTION = "lua-TestMore : an Unit Testing Framework"
 m._COPYRIGHT = "Copyright (c) 2009-2018 Francois Perrad"
 return m


### PR DESCRIPTION
This is how it is done in subtest() of Test::Builder in Perl
note() doesn't display "# Subtest ..." warnings during non-verbose
mode of "prove"